### PR TITLE
added dateutil dependency to README + requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project currently requires the dev version of TensorFlow available on Githu
 In addition, please `pip install` the following packages:
 - `prettytensor`
 - `progressbar`
+- `dateutil`
 
 ## Running in Docker
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 prettytensor
 progressbar
+dateutil
 ipdb


### PR DESCRIPTION
didn't see this in the transitive dependencies and it is imported by `launchers/run_mnist_exp.py`