### PR TITLE
Readme: Update Docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In addition, please `pip install` the following packages:
 
 ```bash
 $ git clone git@github.com:openai/InfoGAN.git
-$ docker run -v $(pwd)/InfoGAN:/InfoGAN -w /InfoGAN -it -p 8888:8888 gcr.io/tensorflow/tensorflow:r0.9rc0-devel
+$ docker run -v $(pwd)/InfoGAN:/InfoGAN -w /InfoGAN -it -p 8888:8888 tensorflow/tensorflow:r0.9rc0-devel
 root@X:/InfoGAN# pip install -r requirements.txt
 root@X:/InfoGAN# python launchers/run_mnist_exp.py
 ```


### PR DESCRIPTION
Replace link to gcr.io and link instead to the same image on Docker Hub as it doesn't work anymore.

See [link](https://hub.docker.com/layers/tensorflow/tensorflow/r0.9rc0-devel/images/sha256-8519aa28b3b47319511aedf896d0d914c5a8e28e5664a098f572165ed229c72d) to tensorflow/tensorflow:r0.9rc0-devel.

Fixes https://github.com/openai/InfoGAN/issues/30.