### PR TITLE
Readme: Add options to commands to fix issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In addition, please `pip install` the following packages:
 $ git clone git@github.com:openai/InfoGAN.git
 $ docker run -v $(pwd)/InfoGAN:/InfoGAN -w /InfoGAN -it -p 8888:8888 gcr.io/tensorflow/tensorflow:r0.9rc0-devel
 root@X:/InfoGAN# pip install -r requirements.txt
-root@X:/InfoGAN# python launchers/run_mnist_exp.py
+root@X:/InfoGAN# PYTHONPATH='.' python launchers/run_mnist_exp.py
 ```
 
 ## Running Experiment
@@ -33,5 +33,5 @@ PYTHONPATH='.' python launchers/run_mnist_exp.py
 You can launch TensorBoard to view the generated images:
 
 ```bash
-tensorboard --logdir logs/mnist
+tensorboard --port 8888 --logdir logs/mnist
 ```


### PR DESCRIPTION
The Docker container is mapping port `8888` from guest to host but Tensorboard starts on port `6006`. Add port option to Tensorboard to start on the specified port.
Add `PYTHONPATH` environment variable to python command in Docker section to solve issue with conflicting imports.